### PR TITLE
Force Fancy Graphics when rendering a Trophy displaying an Item

### DIFF
--- a/run/config/amazingtrophies/trophies/test/lightning.json
+++ b/run/config/amazingtrophies/trophies/test/lightning.json
@@ -6,7 +6,7 @@
     },
     "model": {
         "type": "item",
-        "item": "minecraft:lit_furnace",
+        "registryName": "minecraft:lit_furnace",
         "meta": 2,
         "yawOffset": -90.0
     }

--- a/run/config/amazingtrophies/trophies/test/xp.json
+++ b/run/config/amazingtrophies/trophies/test/xp.json
@@ -7,6 +7,6 @@
     },
     "model": {
         "type": "item",
-        "item": "minecraft:diamond_pickaxe"
+        "registryName": "minecraft:diamond_pickaxe"
     }
 }

--- a/src/main/java/glowredman/amazingtrophies/model/ItemTrophyModelHandler.java
+++ b/src/main/java/glowredman/amazingtrophies/model/ItemTrophyModelHandler.java
@@ -6,6 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
@@ -117,6 +118,17 @@ public class ItemTrophyModelHandler extends PedestalTrophyModelHandler {
 
         public Render() {
             this.setRenderManager(RenderManager.instance);
+        }
+
+        @Override
+        public void doRender(EntityItem p_76986_1_, double p_76986_2_, double p_76986_4_, double p_76986_6_,
+            float p_76986_8_, float p_76986_9_) {
+            // enable fancy graphics while the item is rendered
+            GameSettings options = this.renderManager.options;
+            boolean fancyGraphics = options.fancyGraphics;
+            options.fancyGraphics = true;
+            super.doRender(p_76986_1_, p_76986_2_, p_76986_4_, p_76986_6_, p_76986_8_, p_76986_9_);
+            options.fancyGraphics = fancyGraphics;
         }
 
         @Override


### PR DESCRIPTION
When playing with "Fast" Graphics (instead of "Fancy"), a dropped item is rendered as a 2D image, which always faces the player. This behaviour is not wanted for trophies, as its item should always have depth and the same orientation relative to the pedestal.

This change force-enables fancy graphics when rendering the trophy item and resets the option afterwards. ***However, I don't know if this has any sideeffects, especially with future multi-threaded rendering (CC: @mitchej123).***

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15121.