### PR TITLE
Fix flickering on "Graphics: Fast"

### DIFF
--- a/src/main/java/glowredman/amazingtrophies/model/ItemTrophyModelHandler.java
+++ b/src/main/java/glowredman/amazingtrophies/model/ItemTrophyModelHandler.java
@@ -2,18 +2,29 @@ package glowredman.amazingtrophies.model;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
-import net.minecraft.client.settings.GameSettings;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemCloth;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.oredict.OreDictionary;
 
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
@@ -131,21 +142,186 @@ public class ItemTrophyModelHandler extends PedestalTrophyModelHandler {
         }
 
         @Override
-        public void doRender(EntityItem p_76986_1_, double p_76986_2_, double p_76986_4_, double p_76986_6_,
-            float p_76986_8_, float p_76986_9_) {
-            // enable fancy graphics while the item is rendered
-            GameSettings options = this.renderManager.options;
-            boolean fancyGraphics = options.fancyGraphics;
-            options.fancyGraphics = true;
-            super.doRender(p_76986_1_, p_76986_2_, p_76986_4_, p_76986_6_, p_76986_8_, p_76986_9_);
-            options.fancyGraphics = fancyGraphics;
+        public void doRender(EntityItem entityItem, double x, double y, double z, float p_76986_8_,
+            float partialTickTime) {
+            ItemStack stack = entityItem.getEntityItem();
+
+            this.bindEntityTexture(entityItem);
+            TextureUtil.func_152777_a(false, false, 1.0F);
+
+            this.random.setSeed(187L);
+
+            GL11.glPushMatrix();
+            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+
+            // render with custom renderer
+            if (ForgeHooksClient.renderEntityItem(
+                entityItem,
+                stack,
+                0.0f,
+                0.0f,
+                this.random,
+                this.renderManager.renderEngine,
+                this.field_147909_c,
+                1));
+
+            // render as 3D block
+            else if (stack.getItemSpriteNumber() == 0 && stack.getItem() instanceof ItemBlock
+                && RenderBlocks.renderItemIn3d(
+                    Block.getBlockFromItem(stack.getItem())
+                        .getRenderType())) {
+                            Block block = Block.getBlockFromItem(stack.getItem());
+                            int renderType = block.getRenderType();
+                            float scale = renderType == 1 || renderType == 19 || renderType == 12 || renderType == 2
+                                ? 0.5f
+                                : 0.25F;
+
+                            if (block.getRenderBlockPass() > 0) {
+                                GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
+                                GL11.glEnable(GL11.GL_BLEND);
+                                OpenGlHelper.glBlendFunc(
+                                    GL11.GL_SRC_ALPHA,
+                                    GL11.GL_ONE_MINUS_SRC_ALPHA,
+                                    GL11.GL_ONE,
+                                    GL11.GL_ZERO);
+                            }
+
+                            GL11.glScalef(scale, scale, scale);
+
+                            GL11.glPushMatrix();
+                            this.renderBlocksRi.renderBlockAsItem(block, stack.getItemDamage(), 1.0F);
+                            GL11.glPopMatrix();
+
+                            if (block.getRenderBlockPass() > 0) {
+                                GL11.glDisable(GL11.GL_BLEND);
+                            }
+                        }
+
+            // render as item or 2D block (e.g. Webs)
+            else {
+                if (stack.getItem()
+                    .requiresMultipleRenderPasses()) {
+                    GL11.glScalef(0.5F, 0.5F, 0.5F);
+
+                    for (int pass = 0; pass < stack.getItem()
+                        .getRenderPasses(stack.getItemDamage()); ++pass) {
+                        this.random.setSeed(187L);
+                        int color = stack.getItem()
+                            .getColorFromItemStack(stack, pass);
+                        float r = (float) (color >> 16 & 0xFF) / 255.0F;
+                        float g = (float) (color >> 8 & 0xFF) / 255.0F;
+                        float b = (float) (color & 0xFF) / 255.0F;
+                        GL11.glColor4f(r, g, b, 1.0F);
+                        this.renderDroppedItem(
+                            entityItem,
+                            stack.getItem()
+                                .getIcon(stack, pass),
+                            1,
+                            partialTickTime,
+                            r,
+                            g,
+                            b,
+                            pass);
+                    }
+                } else {
+                    if (stack.getItem() instanceof ItemCloth) {
+                        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
+                        GL11.glEnable(GL11.GL_BLEND);
+                        OpenGlHelper
+                            .glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
+                    }
+
+                    GL11.glScalef(0.5F, 0.5F, 0.5F);
+
+                    int color = stack.getItem()
+                        .getColorFromItemStack(stack, 0);
+                    float r = (float) (color >> 16 & 255) / 255.0F;
+                    float g = (float) (color >> 8 & 255) / 255.0F;
+                    float b = (float) (color & 255) / 255.0F;
+                    this.renderDroppedItem(entityItem, stack.getIconIndex(), 1, partialTickTime, r, g, b, 0);
+
+                    if (stack.getItem() instanceof ItemCloth) {
+                        GL11.glDisable(GL11.GL_BLEND);
+                    }
+                }
+            }
+
+            GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+            GL11.glPopMatrix();
+            this.bindEntityTexture(entityItem);
+            TextureUtil.func_147945_b();
         }
 
-        @Override
-        public boolean shouldBob() {
-            return false;
-        }
+        private void renderDroppedItem(EntityItem entityItem, IIcon icon, int count, float partialTickTime, float r,
+            float g, float b, int pass) {
+            Tessellator tessellator = Tessellator.instance;
 
+            if (icon == null) {
+                TextureManager texturemanager = Minecraft.getMinecraft()
+                    .getTextureManager();
+                ResourceLocation resourcelocation = texturemanager.getResourceLocation(
+                    entityItem.getEntityItem()
+                        .getItemSpriteNumber());
+                icon = ((TextureMap) texturemanager.getTexture(resourcelocation)).getAtlasSprite("missingno");
+            }
+
+            float minU = icon.getMinU();
+            float maxU = icon.getMaxU();
+            float minV = icon.getMinV();
+            float maxV = icon.getMaxV();
+
+            GL11.glPushMatrix();
+
+            float f1 = 0.0625F;
+            float f2 = 0.021875F;
+            ItemStack itemstack = entityItem.getEntityItem();
+
+            GL11.glTranslatef(-0.5f, -0.25f, -0.5f * (f1 + f2));
+
+            GL11.glTranslatef(0f, 0f, f1 + f2);
+
+            if (itemstack.getItemSpriteNumber() == 0) {
+                this.bindTexture(TextureMap.locationBlocksTexture);
+            } else {
+                this.bindTexture(TextureMap.locationItemsTexture);
+            }
+
+            GL11.glColor4f(r, g, b, 1.0F);
+            ItemRenderer
+                .renderItemIn2D(tessellator, maxU, minV, minU, maxV, icon.getIconWidth(), icon.getIconHeight(), f1);
+
+            if (itemstack.hasEffect(pass)) {
+
+                // render holographic effect
+
+                GL11.glDepthFunc(GL11.GL_EQUAL);
+                GL11.glDisable(GL11.GL_LIGHTING);
+                this.renderManager.renderEngine.bindTexture(RES_ITEM_GLINT);
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glBlendFunc(GL11.GL_SRC_COLOR, GL11.GL_ONE);
+                GL11.glColor4f(0.38f, 0.19f, 0.608f, 1.0F);
+                GL11.glMatrixMode(GL11.GL_TEXTURE);
+                GL11.glPushMatrix();
+                GL11.glScalef(0.125F, 0.125F, 0.125F);
+                float f3 = (float) (Minecraft.getSystemTime() % 3000L) / 3000.0F * 8.0F;
+                GL11.glTranslatef(f3, 0.0F, 0.0F);
+                GL11.glRotatef(-50.0F, 0.0F, 0.0F, 1.0F);
+                ItemRenderer.renderItemIn2D(tessellator, 0.0F, 0.0F, 1.0F, 1.0F, 255, 255, f1);
+                GL11.glPopMatrix();
+                GL11.glPushMatrix();
+                GL11.glScalef(0.125F, 0.125F, 0.125F);
+                f3 = (float) (Minecraft.getSystemTime() % 4873L) / 4873.0F * 8.0F;
+                GL11.glTranslatef(-f3, 0.0F, 0.0F);
+                GL11.glRotatef(10.0F, 0.0F, 0.0F, 1.0F);
+                ItemRenderer.renderItemIn2D(tessellator, 0.0F, 0.0F, 1.0F, 1.0F, 255, 255, f1);
+                GL11.glPopMatrix();
+                GL11.glMatrixMode(GL11.GL_MODELVIEW);
+                GL11.glDisable(GL11.GL_BLEND);
+                GL11.glEnable(GL11.GL_LIGHTING);
+                GL11.glDepthFunc(GL11.GL_LEQUAL);
+            }
+
+            GL11.glPopMatrix();
+        }
     }
-
 }

--- a/src/main/resources/META-INF/amazingtrophies_at.cfg
+++ b/src/main/resources/META-INF/amazingtrophies_at.cfg
@@ -1,1 +1,4 @@
 public net.minecraft.client.Minecraft field_110449_ao # defaultResourcePacks
+protected net.minecraft.client.renderer.entity.RenderItem field_77025_h # random
+protected net.minecraft.client.renderer.entity.RenderItem field_110798_h # RES_ITEM_GLINT
+protected net.minecraft.client.renderer.entity.RenderItem field_147913_i # renderBlocksRi


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16459

The super methods<sup>1</sup> were copied 1:1 and then stripped of any code which can't be reached. Only the branch for fancy graphics has been kept, the one for fast graphics has been removed. Because of this, overriding the setting isn't needed anymore (this caused the flickering).

<sup>1</sup> In theory, wideing the scope of `renderDroppedItem()` and then overriding it would be enough, but this method was added by Forge and thus cannot be ATed (at least not in dev). So at the moment, `doRender()` must be overridden too to ensure the modified `renderDroppedItem()` is called.